### PR TITLE
Added python script to warm up cache on any server

### DIFF
--- a/scripts/warm_cache.py
+++ b/scripts/warm_cache.py
@@ -1,0 +1,61 @@
+#!/usr/bin/python
+
+import argparse
+import multiprocessing
+import urllib2
+
+
+class bcolors:
+    INFO = '\033[95m'
+    WARNING = '\033[93m'
+    FAIL = '\033[91m'
+    ENDC = '\033[0m'
+    UNDERLINE = '\033[4m'
+
+
+def colorize(text, color):
+    return color + text + bcolors.ENDC
+
+
+# Class for making requests against the server
+class Requester(multiprocessing.Process):
+    def __init__(self, host, symbol):
+        multiprocessing.Process.__init__(self)
+        self.host = host
+        self.symbol = symbol
+
+    def run(self):
+        target = self.host + "/sentiment?symbol={}".format(self.symbol)
+        if not target.startswith("http://"):
+            target = "http://{}".format(target)
+
+        print "Requesting: {}".format(target)
+        try:
+            urllib2.urlopen(target)
+            print colorize("       Got: {}".format(target), bcolors.INFO)
+        except:
+            print colorize("    FAILED: {}".format(target), bcolors.FAIL)
+
+
+# Tickers to test with
+default_symbols = ['AAPL', 'GOOGL', 'FB', 'TSLA']
+
+# Parse arguments
+parser = argparse.ArgumentParser(description="Warm up the cache")
+parser.add_argument('hostname', help="the hostname of the server")
+parser.add_argument('-s',
+                    '--symbols',
+                    nargs='+',
+                    help='Symbols to lookup (default = {})'
+                    .format(' '.join(default_symbols)),
+                    default=default_symbols)
+args = parser.parse_args()
+
+# Build list of requests to make
+requests = []
+for symbol in args.symbols:
+    requests.append(Requester(args.hostname, symbol))
+
+# Make requests in parallel
+for request in requests:
+    request.start()


### PR DESCRIPTION
It makes parallel requests to the server for each default symbol (the
ones we use to perf test), although you can specify a list of symbols to
'warm up'.  You must specify the server hostname, and for localhost, you
must specify the port (`scripts/warm_cache.py localhost:3000`).