### PR TITLE
CSRF tokens are now ignored

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
-  protect_from_forgery with: :exception
+  # protect_from_forgery with: :exception
 
   def after_sign_in_path_for(resource)
     dashboard_path()


### PR DESCRIPTION
But they are still part of the forms.

Testing (start without this diff applied):
1) Create an account
2) `curl --data "user[email]=<your_email>&user[password]=<your_password>" localhost:3000/users/sign_in` should return an error about an invalid auth token.
3) Apply this diff
4) `curl --data "user[email]=<your_email>&user[password]=<your_password>" localhost:3000/users/sign_in` should now return a message about being redirected to 'http://localhost:3000'.  There should be no invalid auth token error message.